### PR TITLE
Enhance BlueTakk sessions

### DIFF
--- a/BlueTakk/templates.py
+++ b/BlueTakk/templates.py
@@ -1,0 +1,24 @@
+"""Reusable templates for common MITM actions."""
+
+import asyncio
+from mac_mitm import MacMITMProxy
+
+
+async def mac_notification_mitm(target_address: str) -> None:
+    """Forward notifications from the target and attempt to inject one."""
+    proxy = MacMITMProxy(target_address)
+    await proxy.connect_to_target()
+
+    async def log_notification(sender, data):
+        print(f"{sender}: {data}")
+
+    for service in proxy.target_services:
+        for char in service.characteristics:
+            if "notify" in getattr(char, "properties", []):
+                await proxy.client.start_notify(char.uuid, log_notification)
+
+    # Example injection of a dummy notification
+    if proxy.target_services:
+        first = proxy.target_services[0].characteristics[0]
+        await proxy.forward_write(first.uuid, b"template-notify")
+    await asyncio.sleep(5)

--- a/BlueTakk/tests/test_pairing.py
+++ b/BlueTakk/tests/test_pairing.py
@@ -10,3 +10,18 @@ def test_pair_and_exchange():
     out_a, out_b = asyncio.run(simulate_exchange(a, b, msgs_a, msgs_b, interval=0))
     assert out_a == ["B:hello"]
     assert out_b == ["A:hi", "A:there"]
+
+
+def test_pair_request_modifier():
+    captured = {}
+
+    def modifier(req):
+        captured.update(req)
+        req["address"] = "XX"
+        return req
+
+    a = VirtualPeripheral("A")
+    b = VirtualPeripheral("B")
+    a.pair(b, request_modifier=modifier)
+    assert a.last_pair_request["address"] == "XX"
+    assert captured["name"] == "B"

--- a/BlueTakk/tests/test_simulator.py
+++ b/BlueTakk/tests/test_simulator.py
@@ -106,6 +106,7 @@ def test_cli_vuln_path(monkeypatch, capsys):
 
     inputs = iter(["2", "AA:BB:CC:DD:EE:FF", "6"])
     monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+    monkeypatch.setenv("BLEAK_SELECTED_ADAPTER", "test")
 
     bluehakk.current_os = "posix"
     asyncio.run(bluehakk.main_menu())

--- a/BlueTakk/utility_scripts/check_bt_utilities.py
+++ b/BlueTakk/utility_scripts/check_bt_utilities.py
@@ -318,4 +318,19 @@ def visualize_results(live=False):
         with open(data_file, "r") as f:
             try:
                 data = json.load(f)
+            except json.decoder.JSONDecodeError:
+                data = {}
+        bleak_stats.show_stats(data)
+
+# ----------------- Module Interface -----------------
+if __name__ == "__main__":
+    if check_and_setup():
+        run_os_monitoring()
+        os_type = detect_os()
+        if os_type == "mac":
+            asyncio.run(run_deepble_live_scan())
+            export_os_capture()
+        elif os_type == "windows":
+            asyncio.run(run_windows_live_scan())
+            export_os_capture()
 


### PR DESCRIPTION
## Summary
- fix truncated `check_bt_utilities.py`
- allow modifying reverse pair request in `VirtualPeripheral`
- add interactive session support in CLI
- extend GUI with per‑session windows
- provide MITM notification template
- update tests for new behaviour

## Testing
- `pytest BlueTakk/tests -q`
- `pytest -q` *(fails: import mismatches in duplicated tests)*

------
https://chatgpt.com/codex/tasks/task_e_6844d7b7507c8328a06c8e2ae368d79c