### PR TITLE
Extend peripheral simulator

### DIFF
--- a/BlueTakk/tests/test_simulator.py
+++ b/BlueTakk/tests/test_simulator.py
@@ -119,3 +119,10 @@ def test_cli_vuln_path(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "Vulnerability testing completed" in out
 
+
+def test_supported_platform_ish(monkeypatch):
+    from peripheral_simulator import simulator as sim
+
+    monkeypatch.setattr(sim.sys, "platform", "ish", raising=False)
+    assert sim.is_supported_platform()
+


### PR DESCRIPTION
## Summary
- expand peripheral simulator to support macOS/iSH, Linux and Windows
- add Linux and Windows simulator stubs
- treat iSH as a supported platform
- test supported platform detection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845dd8dfaac83288b2bbe4e8081e2f6