### PR TITLE
Improve MITM modules and debugger

### DIFF
--- a/BlueTakk/ble_session_debugger.py
+++ b/BlueTakk/ble_session_debugger.py
@@ -52,3 +52,64 @@ def handle_notification(sender, data):
         logging.info(f"Notification from {sender}: {decoded_data}")
     except Exception as e:
         logging.error(f"Error handling notification from {sender}: {e}")
+
+
+async def debugger_loop(address: str):
+    """Interactive BLE debugging session."""
+    from bleak import BleakClient
+
+    async with BleakClient(address) as client:
+        if not client.is_connected:
+            print("Failed to connect to device")
+            return
+        services = await client.get_services()
+        writable = find_writable_characteristics(services)
+        notifiable = find_notifiable_characteristics(services)
+
+        while True:
+            print_menu(writable, notifiable)
+            choice = input("Select option: ").strip().upper()
+
+            if choice == "A":
+                idx = input("Index to listen: ").strip()
+                if idx.isdigit() and 0 < int(idx) <= len(notifiable):
+                    char = notifiable[int(idx) - 1]
+                    await client.start_notify(char.uuid, handle_notification)
+                    input("Listening...press Enter to stop")
+                    await client.stop_notify(char.uuid)
+            elif choice == "B":
+                for char in notifiable:
+                    await client.start_notify(char.uuid, handle_notification)
+                input("Listening to all...press Enter to stop")
+                for char in notifiable:
+                    await client.stop_notify(char.uuid)
+            elif choice == "C":
+                payload = b"test"
+                target = input("Send to all or index: ")
+                if target.isdigit() and 0 < int(target) <= len(writable):
+                    await client.write_gatt_char(writable[int(target)-1].uuid, payload)
+                else:
+                    for char in writable:
+                        await client.write_gatt_char(char.uuid, payload)
+            elif choice == "D":
+                hex_str = input("Hex payload: ").strip()
+                try:
+                    data = bytes.fromhex(hex_str)
+                except Exception:
+                    print("Invalid hex string")
+                    continue
+                idx = input("Characteristic index: ")
+                if idx.isdigit() and 0 < int(idx) <= len(writable):
+                    await client.write_gatt_char(writable[int(idx)-1].uuid, data)
+            elif choice == "M":
+                print("Mimic mode not implemented")
+            elif choice == "E":
+                break
+
+
+if __name__ == "__main__":  # pragma: no cover - manual use
+    import sys
+    if len(sys.argv) < 2:
+        print("Usage: python ble_session_debugger.py <device_address>")
+        sys.exit(1)
+    asyncio.run(debugger_loop(sys.argv[1]))

--- a/BlueTakk/tests/test_mitm_and_shell.py
+++ b/BlueTakk/tests/test_mitm_and_shell.py
@@ -1,0 +1,77 @@
+import asyncio
+import sys
+import types
+from types import SimpleNamespace
+import importlib
+
+import blueshell
+from peripheral_simulator import simulator as sim
+
+def _ensure_bleak_exc():
+    if "bleak.exc" not in sys.modules:
+        exc_mod = types.ModuleType("bleak.exc")
+        setattr(exc_mod, "BleakError", Exception)
+        sys.modules["bleak.exc"] = exc_mod
+
+def test_mac_mitm_import(monkeypatch):
+    _ensure_bleak_exc()
+    monkeypatch.setitem(sys.modules, "objc", types.ModuleType("objc"))
+    import mac_mitm
+    importlib.reload(mac_mitm)
+    assert hasattr(mac_mitm, "MacMITMProxy")
+
+def test_win_mitm_import(monkeypatch):
+    _ensure_bleak_exc()
+    monkeypatch.setitem(sys.modules, "winrt", types.ModuleType("winrt"))
+    import win_mitm
+    importlib.reload(win_mitm)
+    assert hasattr(win_mitm, "WindowsMITMProxy")
+
+# --- Blueshell UUID detection ---
+async def _fake_get_shell_service_uuids(addr):
+    return {}
+
+class DummyChar:
+    def __init__(self, uuid):
+        self.uuid = uuid
+        self.properties = ["read", "write"]
+
+class DummyService:
+    def __init__(self):
+        self.uuid = "service"
+        self.description = "Shell Service"
+        self.characteristics = [DummyChar("char")]
+
+class DummyClient:
+    def __init__(self, address):
+        self.address = address
+        self.is_connected = True
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def get_services(self):
+        return [DummyService()]
+
+# --- Tests ---
+
+def test_get_shell_uuids_fallback(monkeypatch):
+    monkeypatch.setattr(blueshell.bleak_discover_2, "get_shell_service_uuids", _fake_get_shell_service_uuids)
+    monkeypatch.setattr(blueshell, "BleakClient", lambda addr: DummyClient(addr))
+    uuids = asyncio.run(blueshell.get_shell_uuids("AA"))
+    assert uuids["read_char_uuid"] == "char"
+
+
+def test_start_simulator_paths(monkeypatch):
+    monkeypatch.setattr(sim.sys, "platform", "win32", raising=False)
+    monkeypatch.setattr(sim, "IS_WIN", True, raising=False)
+    monkeypatch.setattr(sim, "IS_LINUX", False, raising=False)
+    called = {}
+    monkeypatch.setattr(sim, "WindowsPeripheralSimulator", lambda p: SimpleNamespace(start=lambda: called.setdefault("win", True)))
+    sim.start_simulator("speaker")
+    assert called.get("win")
+
+


### PR DESCRIPTION
## Summary
- handle missing optional dependencies gracefully
- implement MITM proxy logic for macOS and Windows
- expand `ble_session_debugger` with interactive loop
- refine blueshell service UUID detection
- update Bluehakk CLI for robust proxy and shell launching
- add tests for MITM modules, simulator paths and blueshell detection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845ebc25cfc8328a0e1c4e3a1d71709