### PR TITLE
Fix CLI path issues and error messages

### DIFF
--- a/BlueTakk/bleshellexploit.py
+++ b/BlueTakk/bleshellexploit.py
@@ -42,7 +42,11 @@ async def scan_and_identify_exploitable_services(device_address):
                             "properties": char.properties
                         })
     except Exception as e:
-        print(f"Error scanning {device_address}: {e}")
+        msg = str(e)
+        if "PeripheralDelegate is overriding" in msg:
+            print("Warning: PeripheralDelegate already defined; continuing scan.")
+        else:
+            print(f"Error scanning {device_address}: {e}")
     return exploitable_services
 
 async def exploit_device(device_address, char_uuid):

--- a/BlueTakk/bluehakk.py
+++ b/BlueTakk/bluehakk.py
@@ -97,7 +97,8 @@ def store_session_details(device, details):
 
 def launch_shell_session(address: str) -> None:
     """Launch blueshell in a detached subprocess and track it."""
-    script = "blueshell.py"
+    script_dir = os.path.dirname(__file__)
+    script = os.path.join(script_dir, "blueshell.py")
     if not os.path.exists(script):
         raise FileNotFoundError(script)
     cmd = [sys.executable, script, "--device_address", address]
@@ -273,13 +274,19 @@ async def main_menu():
             visualize_vuln_results(results)
         elif option == "3":
             print("\nLaunching session stats (using bleak_stats.py)...")
-            subprocess.run(["python3", "bleak_stats.py"])
+            stats_path = os.path.join(os.path.dirname(__file__), "bleak_stats.py")
+            subprocess.run(["python3", stats_path])
         elif option == "4":
             print("Generating static visualization from last captured session...")
             bt_util.visualize_results(live=False)
         elif option == "5":
             target_address = input("Enter the target BLE device address: ").strip()
-            script = "win_mitm.py" if current_os == 'nt' else "mac_mitm.py" if current_os == 'osx' else None
+            if current_os == 'nt':
+                script = os.path.join(os.path.dirname(__file__), 'win_mitm.py')
+            elif current_os == 'osx':
+                script = os.path.join(os.path.dirname(__file__), 'mac_mitm.py')
+            else:
+                script = None
             if script is None:
                 print("MITM proxy not supported on this OS.")
             else:
@@ -305,6 +312,8 @@ async def main_menu():
                     start_simulator(items[idx])
                 else:
                     print("Invalid selection")
+            except ValueError:
+                print("Invalid selection. Please enter the profile number.")
             except Exception as exc:
                 print(f"Failed to start simulator: {exc}")
         elif option == "8":

--- a/bluehakk/bluehakk.py
+++ b/bluehakk/bluehakk.py
@@ -118,7 +118,8 @@ async def main_menu():
             visualize_vuln_results(results)
         elif option == "3":
             print("\nLaunching session stats (using bleak_stats.py)...")
-            subprocess.run(["python3", "bleak_stats.py"])
+            stats_path = os.path.join(os.path.dirname(__file__), "bleak_stats.py")
+            subprocess.run(["python3", stats_path])
         elif option == "4":
             print("Generating static visualization from last captured session...")
             bt_util.visualize_results(live=False)
@@ -126,11 +127,13 @@ async def main_menu():
             if current_os == 'nt':
                 print("Launching Windows MITM Proxy...")
                 target_address = input("Enter the target BLE device address: ").strip()
-                subprocess.run(["python3", "win_mitm.py", target_address])
+                script = os.path.join(os.path.dirname(__file__), "win_mitm.py")
+                subprocess.run(["python3", script, target_address])
             elif current_os == 'osx':
                 print("Launching Mac-in-the-Middle Proxy...")
                 target_address = input("Enter the target BLE device address: ").strip()
-                subprocess.run(["python3", "mac_mitm.py", target_address])
+                script = os.path.join(os.path.dirname(__file__), "mac_mitm.py")
+                subprocess.run(["python3", script, target_address])
             else:
                 print("Unsupported...")
         elif option == "6":
@@ -148,6 +151,8 @@ async def main_menu():
                     start_simulator(items[idx])
                 else:
                     print("Invalid selection")
+            except ValueError:
+                print("Invalid selection. Please enter the profile number.")
             except Exception as exc:
                 print(f"Failed to start simulator: {exc}")
         else:


### PR DESCRIPTION
## Summary
- improve scan error handling
- use absolute paths for MITM, stats, and shell scripts
- clarify peripheral simulator selection prompt

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845fc9eaa808328aff9d54c6a9e42ce