### PR TITLE
Fix mac MITM initialization and add verbose vulnerability testing

### DIFF
--- a/BlueTakk/bleshellexploit.py
+++ b/BlueTakk/bleshellexploit.py
@@ -96,10 +96,20 @@ def run_scan(mode, device_address=None):
     return asyncio.run(run_scan_async(mode, device_address))
 
 def run_exploit(device_address):
-    """
-    Synchronous wrapper for exploitation (for standalone usage).
-    """
-    return asyncio.run(run_scan_async("scan_specific", device_address))
+    """Run exploitation against a specific device with verbose output."""
+    return asyncio.run(_run_exploit_verbose(device_address))
+
+async def _run_exploit_verbose(device_address):
+    results = await run_scan_async("scan_specific", device_address)
+    for res in results:
+        char_uuid = res.get("char_uuid")
+        if not char_uuid:
+            continue
+        print(f"\n[+] Running overflow test on {char_uuid}")
+        await test_overflow(device_address, char_uuid)
+        print(f"[+] Running input limit test on {char_uuid}")
+        await test_input_limits(device_address, char_uuid)
+    return results
 
 # ---------------- Vulnerability Test Functions ----------------
 async def test_overflow(device_address, char_uuid):

--- a/BlueTakk/mac_mitm.py
+++ b/BlueTakk/mac_mitm.py
@@ -17,16 +17,6 @@ except Exception:  # pragma: no cover - fallback when pyobjc missing
 if TYPE_CHECKING:
     from CoreBluetooth import CBPeripheralManager  # pragma: no cover
 
-def safe_define_objc_class(name, bases, attrs):
-    if objc is None:
-        return type(name, bases, attrs)
-    class_list = getattr(objc, "classList", None)
-    look_up_class = getattr(objc, "lookUpClass", None)
-    if class_list and look_up_class:
-        if name in class_list():
-            return look_up_class(name)
-    return type(name, bases, attrs)
-
 # Import CoreBluetooth classes via pyobjc if available
 if objc is not None and hasattr(objc, "loadBundle"):
     objc.loadBundle(
@@ -55,10 +45,6 @@ class MITMPeripheralDelegate(NSObject):
         peripheralManager.respondToRequest_withResult_(request, 0)  # 0 for success
 
     # Additional delegate methods can be defined here.
-
-PeripheralDelegate = safe_define_objc_class("PeripheralDelegate", (NSObject,), {
-    # ...class attributes and methods...
-})
 
 # MITM Proxy Class
 class MacMITMProxy:


### PR DESCRIPTION
## Summary
- avoid Objective-C class conflicts in `mac_mitm.py`
- provide verbose vulnerability testing via `run_exploit` in `bleshellexploit`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845fff4c180832898b072a573547401